### PR TITLE
models/cart.py: override delete method to clear item relations

### DIFF
--- a/api/models/cart.py
+++ b/api/models/cart.py
@@ -27,6 +27,10 @@ class Cart(Model):
     created = DateTimeField(auto_now_add=True)
     updated = DateTimeField(auto_now=True)
 
+    def delete(self, using=None, keep_parents=False):
+        self.items.clear()
+        return super().delete(using, keep_parents)
+
     @property
     def total(self):
         total = 0


### PR DESCRIPTION
/carts/current/ endpoint ya estaba implementado
+ delete method en Cart para borrar relaciones con Items