### PR TITLE
views/cart.py: /carts/<id>/checkout needs to be authentycated

### DIFF
--- a/api/exceptions.py
+++ b/api/exceptions.py
@@ -37,3 +37,9 @@ class CartCheckoutNotProcessed(APIException):
     status_code = HTTP_400_BAD_REQUEST
     default_detail = 'Cart has bot been processed.'
     default_code = 'cart_not_processed'
+
+
+class CartCheckoutNeedsUser(APIException):
+    status_code = HTTP_400_BAD_REQUEST
+    default_detail = 'Cart checkout needs a valid user.'
+    default_code = 'cart_checkout_needs_user'

--- a/api/models/cart.py
+++ b/api/models/cart.py
@@ -95,3 +95,6 @@ class Cart(Model):
 
     def is_empty(self):
         return not self.get_cart_items().exists()
+
+    def is_anonymous(self):
+        return not self.user

--- a/api/serializers/cart.py
+++ b/api/serializers/cart.py
@@ -2,6 +2,7 @@ from rest_framework.serializers import ModelSerializer, \
     SerializerMethodField, Serializer, PrimaryKeyRelatedField, SlugRelatedField
 
 from api.models import Cart, Item
+from api.exceptions import CartCheckoutNeedsUser
 
 
 class CartItemSerializer(Serializer):

--- a/api/tests/cart.py
+++ b/api/tests/cart.py
@@ -495,3 +495,12 @@ class TestPatchCart(BaseCartTest):
 
         response_2 = self._get(pk=cart_2.id, token=token_2)
         self.assertEqual(response_2.data['count'], len(body.get('items')))
+
+
+class TestCartCheckout(BaseCartTest):
+    DETAIL_ENDPOINT = '/api/carts/{pk}/checkout/'
+
+    def test_not_authenticated_checkout_returns_401(self):
+        cart = self.get_cart(items=[1, 2])
+        response = self._get(pk=cart.id)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)


### PR DESCRIPTION
Endpoint returns now 401 if not authenticated.