### PR TITLE
backend/settings.py: docker-compose passes empty values for unexisten…

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -229,6 +229,7 @@ EMAIL_BACKEND = env(
     'django.core.mail.backends.smtp.EmailBackend',
     var_type='string'
 )
+EMAIL_BACKEND = EMAIL_BACKEND or 'django.core.mail.backends.smtp.EmailBackend'
 
 MG_API_KEY = os.getenv('MG_SENDING_KEY', '')
 MG_TRACKING_KEY = os.getenv('MG_TRACKING_KEY') or MG_API_KEY


### PR DESCRIPTION
…t envs and env() doesn't use default values