### PR TITLE
Adding shipping to cart

### DIFF
--- a/.kiro/specs/active-members-endpoint/.config.kiro
+++ b/.kiro/specs/active-members-endpoint/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "61c57d86-0f30-4f78-b6a8-60d3cc57057a", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/cart-delivery-shipping/.config.kiro
+++ b/.kiro/specs/cart-delivery-shipping/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "a4b51cc1-8ff3-477a-836c-1d7662713732", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/cart-delivery-shipping/design.md
+++ b/.kiro/specs/cart-delivery-shipping/design.md
@@ -1,0 +1,291 @@
+# Design Document: Cart Delivery & Shipping
+
+## Overview
+
+This feature adds shipping/delivery support to the Ameba cart. Users choose between home delivery or shop pickup at checkout. The choice is persisted as a `shipping` JSONField on the `Cart` model. Selecting home delivery automatically adds a fixed €4 `DeliveryFee` `CartItem` that is always excluded from discount calculations. The cart's `state` property is extended with two flags that drive the frontend checkout routing.
+
+The implementation is additive: no existing model fields are removed, no existing API contracts are broken. The `CartViewSet` already supports `PATCH /api/carts/{id}/` via `partial_update`; we extend the `CartSerializer` to accept and validate the new `shipping` field through that same endpoint.
+
+---
+
+## Architecture
+
+```mermaid
+flowchart TD
+    Client -->|PATCH /api/carts/id/| CartViewSet
+    CartViewSet --> CartSerializer
+    CartSerializer --> ShippingSerializer
+    ShippingSerializer -->|validates| DeliverySerializer
+    ShippingSerializer -->|validates| ShopPickupSerializer
+    CartSerializer -->|calls| DeliveryFeeService
+    DeliveryFeeService -->|add/remove CartItems row| CartItems
+    CartSerializer -->|saves| Cart
+
+    Cart -->|shipping JSONField| DB[(PostgreSQL)]
+    Cart -->|get_cart_items_with_discounts| DiscountLogic
+    DiscountLogic -->|is_delivery_fee?| DeliveryFeeExemption
+```
+
+The design keeps all new logic inside the existing `api/` app, following the one-file-per-domain convention.
+
+---
+
+## Components and Interfaces
+
+### 1. `ShippingSerializer` (new — `api/serializers/cart.py`)
+
+Validates the `shipping` JSON payload. Contains two optional nested serializers:
+
+```python
+class DeliverySerializer(serializers.Serializer):
+    direccion = serializers.CharField(label=_('address'))
+    ciudad    = serializers.CharField(label=_('city'))
+    telefono  = serializers.CharField(label=_('phone'))
+    dni       = serializers.CharField(label=_('DNI'))
+
+class ShopPickupSerializer(serializers.Serializer):
+    shop = serializers.CharField(label=_('shop'))
+
+class ShippingSerializer(serializers.Serializer):
+    delivery   = DeliverySerializer(required=False, allow_null=True)
+    shop_pickup = ShopPickupSerializer(required=False, allow_null=True)
+
+    def validate(self, data):
+        # Exactly one of delivery / shop_pickup must be present and non-null
+        ...
+```
+
+Validation rules:
+- At least one of `delivery` or `shop_pickup` must be present.
+- At most one may be active (non-null) at a time.
+- All string fields must be non-empty after stripping whitespace.
+
+### 2. `Cart` model changes (`api/models/cart.py`)
+
+**New field:**
+```python
+shipping = JSONField(blank=True, null=True, verbose_name=_('shipping'))
+```
+
+**New migration:** `api/migrations/0082_cart_shipping.py`
+
+**`state` property** — extended with two new keys:
+```python
+needs_shipping_selection     = self.shipping is None
+can_confirm_or_change_shipping = self.shipping is not None
+```
+
+**`get_cart_items_with_discounts` change** — when iterating cart items, if the item is a delivery fee item (`cart_item.item_variant.is_delivery_fee` is `True`), skip the discount lookup and always append `discount: None`.
+
+**`discounts_by_value_desc` change** — return `[]` immediately for delivery-fee item variants.
+
+### 3. `DeliveryFeeService` (new — `api/helpers/delivery_fee.py`)
+
+A small stateless helper that encapsulates add/remove logic so it can be called from both the serializer and any future code paths:
+
+```python
+DELIVERY_FEE_CENTS = 400
+
+def ensure_delivery_fee(cart: Cart) -> None:
+    """Add the DeliveryFee CartItem if not already present."""
+    ...
+
+def remove_delivery_fee(cart: Cart) -> None:
+    """Remove the DeliveryFee CartItem if present."""
+    ...
+```
+
+### 4. `ItemVariant` — delivery fee flag
+
+Rather than creating a new model, we add a boolean `is_delivery_fee` field to `ItemVariant`:
+
+```python
+is_delivery_fee = models.BooleanField(default=False, verbose_name=_('is delivery fee'))
+```
+
+A single `DeliveryFee` `Item` + `ItemVariant` is created via a data migration (price = 4.00, stock = -1, `is_delivery_fee = True`). The service helper looks up this variant by `is_delivery_fee=True`.
+
+**New migration:** `api/migrations/0083_itemvariant_is_delivery_fee.py`
+
+### 5. `CartSerializer` changes (`api/serializers/cart.py`)
+
+- Add `shipping` as a writable field backed by `ShippingSerializer`.
+- Add `shipping` to `CartCheckoutSerializer.fields`.
+- In `update()`: after saving the shipping value, call `ensure_delivery_fee` or `remove_delivery_fee` based on whether `delivery` is present.
+
+### 6. `CartViewSet` — no changes needed
+
+`PATCH /api/carts/{id}/` already routes to `partial_update` → `CartSerializer.update`. No new endpoints or actions are required.
+
+---
+
+## Data Models
+
+### `Cart` (modified)
+
+| Field | Type | Notes |
+|---|---|---|
+| `shipping` | `JSONField(null=True)` | New field. Stores `Shipping` object or `null`. |
+
+### `Shipping` JSON schema
+
+```json
+{
+  "delivery": {
+    "direccion": "string",
+    "ciudad": "string",
+    "telefono": "string",
+    "dni": "string"
+  },
+  "shop_pickup": null
+}
+```
+
+or
+
+```json
+{
+  "delivery": null,
+  "shop_pickup": { "shop": "string" }
+}
+```
+
+At most one key is non-null at a time.
+
+### `ItemVariant` (modified)
+
+| Field | Type | Notes |
+|---|---|---|
+| `is_delivery_fee` | `BooleanField(default=False)` | New flag. Exactly one variant has this set to `True`. |
+
+### `CartItems` (unchanged)
+
+The delivery fee is stored as a regular `CartItems` row linking the delivery-fee `ItemVariant` to the `Cart`. No schema change needed.
+
+---
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Delivery fee present if and only if (iff) delivery is active
+
+*For any* cart, after setting `shipping` to a delivery object, the cart's item variants must include exactly one delivery-fee item variant; and after switching to shop pickup, the cart's item variants must contain no delivery-fee item variant.
+
+**Validates: Requirements 2.1, 2.2, 3.5, 3.6**
+
+---
+
+### Property 2: Delivery fee always excluded from discounts
+
+*For any* cart with an active discount code and a delivery-fee item in its items, `get_cart_items_with_discounts` must return the delivery-fee entry with `discount: None`, regardless of what discounts are attached to other items.
+
+**Validates: Requirements 2.4, 2.5, 6.1, 6.2**
+
+---
+
+### Property 3: Cart amount includes delivery fee at full price
+
+*For any* cart with delivery active and any discount code applied, `cart.amount` must equal the sum of discounted non-fee items plus exactly 400 cents (never less).
+
+**Validates: Requirements 2.3, 6.3**
+
+---
+
+### Property 4: Shipping serializer round-trip
+
+*For any* valid `Shipping` object (either delivery or shop_pickup variant), serializing it and then deserializing the result must produce an equivalent object.
+
+**Validates: Requirements 1.2, 1.3, 1.4, 5.4, 5.5**
+
+---
+
+### Property 5: Invalid shipping payloads are rejected
+
+*For any* shipping payload that is missing required fields or has empty-string values, `ShippingSerializer.is_valid()` must return `False` and the cart must remain unchanged.
+
+**Validates: Requirements 3.2, 3.3, 3.4**
+
+---
+
+### Property 6: Cart state flags are consistent with shipping field
+
+*For any* cart, `needs_shipping_selection` is `True` if and only if `shipping` is `None`, and `can_confirm_or_change_shipping` is `True` if and only if `shipping` is not `None`. The two flags are always logical complements.
+
+**Validates: Requirements 4.1, 4.2, 4.3**
+
+---
+
+### Property 7: CartSerializer exposes shipping field correctly
+
+*For any* cart, the serialized output of `CartSerializer` must include a `shipping` key whose value is `null` when `cart.shipping` is `None`, and contains all expected sub-fields when set.
+
+**Validates: Requirements 5.1, 5.3, 5.4, 5.5**
+
+---
+
+## Error Handling
+
+| Scenario | HTTP Status | Detail |
+|---|---|---|
+| `shipping` payload missing required string field | 400 | DRF validation error from `ShippingSerializer` |
+| `shipping` payload has empty/whitespace string | 400 | Custom validator in `DeliverySerializer` / `ShopPickupSerializer` |
+| Both `delivery` and `shop_pickup` are non-null | 400 | `ShippingSerializer.validate()` raises `ValidationError` |
+| Neither `delivery` nor `shop_pickup` present | 400 | `ShippingSerializer.validate()` raises `ValidationError` |
+| `PATCH` on a cart the user doesn't own | 403 | Existing `CartPermission` |
+| Unauthenticated `PATCH` on a cart | 401 | Existing `CartPermission` |
+
+No new exception classes are needed; standard DRF `ValidationError` is sufficient.
+
+---
+
+## Testing Strategy
+
+Tests live in `api/tests/test_cart_shipping.py` and extend `BaseTest`.
+
+### Unit tests
+
+- `ShippingSerializer` accepts valid delivery payload.
+- `ShippingSerializer` accepts valid shop_pickup payload.
+- `ShippingSerializer` rejects payload with both keys non-null.
+- `ShippingSerializer` rejects payload with neither key.
+- `ShippingSerializer` rejects delivery payload with empty `direccion`.
+- `DeliveryFeeService.ensure_delivery_fee` is idempotent (calling twice doesn't add two rows).
+- `DeliveryFeeService.remove_delivery_fee` is a no-op when no fee is present.
+- `Cart.state` includes `needs_shipping_selection` and `can_confirm_or_change_shipping`.
+- `CartSerializer` output includes `shipping: null` when unset.
+- `CartCheckoutSerializer` output includes `shipping` field.
+
+### Property-based tests
+
+Use [Hypothesis](https://hypothesis.readthedocs.io/) (already available in the Python ecosystem; add to dev dependencies).
+
+Each property test runs a minimum of 100 examples.
+
+**Property test 1** — `test_delivery_fee_present_iff_delivery_active`
+Generate random valid shipping objects (delivery or shop_pickup). After a PATCH, assert delivery-fee presence matches shipping type.
+`# Feature: cart-delivery-shipping, Property 1: Delivery fee present if and only if (iff) delivery is active`
+
+**Property test 2** — `test_delivery_fee_excluded_from_discounts`
+Generate random carts with random discount codes and a delivery-fee item. Assert `get_cart_items_with_discounts` always returns `discount: None` for the fee item.
+`# Feature: cart-delivery-shipping, Property 2: Delivery fee always excluded from discounts`
+
+**Property test 3** — `test_cart_amount_includes_full_delivery_fee`
+Generate random item sets with random discount codes and delivery active. Assert `cart.amount >= 400` and the fee contributes exactly 400 cents.
+`# Feature: cart-delivery-shipping, Property 3: Cart amount includes delivery fee at full price`
+
+**Property test 4** — `test_shipping_serializer_round_trip`
+Generate random valid `Shipping` dicts. Serialize then deserialize and assert structural equality.
+`# Feature: cart-delivery-shipping, Property 4: Shipping serializer round-trip`
+
+**Property test 5** — `test_invalid_shipping_rejected`
+Generate shipping dicts with at least one required field empty or missing. Assert `is_valid()` returns `False`.
+`# Feature: cart-delivery-shipping, Property 5: Invalid shipping payloads are rejected`
+
+**Property test 6** — `test_state_flags_are_complements`
+Generate random carts with `shipping` set to `None` or a valid object. Assert `needs_shipping_selection == (not can_confirm_or_change_shipping)`.
+`# Feature: cart-delivery-shipping, Property 6: Cart state flags are consistent with shipping field`
+
+**Property test 7** — `test_cart_serializer_shipping_field`
+Generate random carts. Assert serialized output always contains a `shipping` key with the correct structure.
+`# Feature: cart-delivery-shipping, Property 7: CartSerializer exposes shipping field correctly`

--- a/.kiro/specs/cart-delivery-shipping/requirements.md
+++ b/.kiro/specs/cart-delivery-shipping/requirements.md
@@ -1,0 +1,100 @@
+# Requirements Document
+
+## Introduction
+
+This feature adds shipping/delivery support to the Ameba cart. At checkout, users choose between home delivery or shop pickup. The choice is stored on the cart as a `shipping` field. If delivery is selected, a fixed €4 delivery fee is added to the cart as a special `CartItem` that is exempt from discount codes. The checkout flow checks whether a shipping preference already exists on the cart and either skips the selection step or presents a confirmation/edit page accordingly.
+
+## Glossary
+
+- **Cart**: The existing `Cart` model that holds a user's selected items before purchase.
+- **CartItem**: A through-model entry linking an `ItemVariant` to a `Cart` (model: `CartItems`).
+- **Delivery**: A home-delivery option containing address, city, phone, and DNI.
+- **ShopPickup**: An in-store pickup option identifying the pickup shop.
+- **Shipping**: A JSON structure on the `Cart` that holds either a `Delivery` or a `ShopPickup` (or both, with one active).
+- **DeliveryFee**: A fixed €4 surcharge added as a `CartItem` when delivery is chosen. Exempt from all discount codes.
+- **Checkout**: The existing multi-step purchase flow ending in payment.
+- **ShippingAPI**: The API surface (endpoints + serializers) that manages the `shipping` field on a `Cart`.
+
+---
+
+## Requirements
+
+### Requirement 1: Shipping Data Model
+
+**User Story:** As a developer, I want a well-defined shipping data structure on the cart, so that delivery and pickup preferences are stored consistently.
+
+#### Acceptance Criteria
+
+1. THE `Cart` model SHALL include a nullable `shipping` JSONField that stores a `Shipping` object.
+2. THE `Shipping` object SHALL contain a `delivery` key of type `Delivery` and/or a `shop_pickup` key of type `ShopPickup`, with at most one active at a time.
+3. THE `Delivery` object SHALL contain the fields: `direccion` (string), `ciudad` (string), `telefono` (string), and `dni` (string).
+4. THE `ShopPickup` object SHALL contain the field: `shop` (string).
+5. WHEN the `shipping` field is null or absent, THE `Cart` SHALL be treated as having no shipping preference set.
+
+---
+
+### Requirement 2: Delivery Fee Cart Item
+
+**User Story:** As a platform operator, I want a €4 delivery fee automatically added to the cart when delivery is chosen, so that the cost is reflected in the cart total.
+
+#### Acceptance Criteria
+
+1. WHEN a user selects home delivery, THE `Cart` SHALL include a `DeliveryFee` `CartItem` representing a fixed charge of 400 cents (€4.00).
+2. WHEN a user switches from delivery to shop pickup, THE `Cart` SHALL remove the `DeliveryFee` `CartItem`.
+3. THE `Cart.amount` property SHALL include the `DeliveryFee` amount in the total when delivery is active.
+4. IF a `discount_code` is applied to the `Cart`, THEN THE `Cart` SHALL NOT apply any discount to the `DeliveryFee` `CartItem`.
+5. THE `DeliveryFee` `CartItem` SHALL be identifiable by a stable flag or type so that discount logic can exclude it unconditionally.
+
+---
+
+### Requirement 3: Set or Update Shipping on Cart
+
+**User Story:** As a user, I want to set or change my delivery/pickup preference on my cart, so that I can control how my order is fulfilled.
+
+#### Acceptance Criteria
+
+1. WHEN a `PATCH /api/carts/{id}/` request is received with a valid `shipping` payload, THE `ShippingAPI` SHALL update the `Cart.shipping` field and return the updated cart.
+2. WHEN the `shipping` payload contains a `delivery` object, THE `ShippingAPI` SHALL validate that `direccion`, `ciudad`, `telefono`, and `dni` are all non-empty strings.
+3. WHEN the `shipping` payload contains a `shop_pickup` object, THE `ShippingAPI` SHALL validate that `shop` is a non-empty string.
+4. IF the `shipping` payload is malformed or missing required fields, THEN THE `ShippingAPI` SHALL return HTTP 400 with a descriptive validation error.
+5. WHEN the `shipping` payload switches from delivery to shop pickup, THE `ShippingAPI` SHALL remove the `DeliveryFee` `CartItem` from the cart.
+6. WHEN the `shipping` payload switches from shop pickup to delivery, THE `ShippingAPI` SHALL add the `DeliveryFee` `CartItem` to the cart.
+
+---
+
+### Requirement 4: Checkout Flow — Shipping Selection Gate
+
+**User Story:** As a user, I want the checkout flow to ask me about delivery only when I haven't already chosen, so that I'm not asked redundant questions.
+
+#### Acceptance Criteria
+
+1. WHEN a user initiates checkout and `Cart.shipping` is null, THE `Cart` state SHALL expose a flag `needs_shipping_selection: true` so the frontend can redirect to the shipping selection page.
+2. WHEN a user initiates checkout and `Cart.shipping` is already set, THE `Cart` state SHALL expose `needs_shipping_selection: false` and a flag `can_confirm_or_change_shipping: true` so the frontend can redirect to the confirmation/edit page.
+3. THE `Cart.state` property SHALL include `needs_shipping_selection` and `can_confirm_or_change_shipping` boolean fields.
+4. WHEN `Cart.shipping` is set and the user confirms without changes, THE `ShippingAPI` SHALL allow proceeding to payment without requiring a re-submission of shipping data.
+
+---
+
+### Requirement 5: Cart Serializer — Shipping Field Exposure
+
+**User Story:** As a frontend developer, I want the cart API response to include the shipping field, so that the UI can display and edit the current shipping preference.
+
+#### Acceptance Criteria
+
+1. THE `CartSerializer` SHALL include the `shipping` field in its output, returning `null` when no shipping preference is set.
+2. THE `CartSerializer` SHALL accept a `shipping` object in `PATCH` requests and delegate validation to the `ShippingSerializer`.
+3. THE `CartCheckoutSerializer` SHALL include the `shipping` field so the checkout summary page can display the chosen delivery method.
+4. WHEN the `shipping` field contains a `delivery` object, THE `CartSerializer` SHALL serialize all four delivery fields (`direccion`, `ciudad`, `telefono`, `dni`).
+5. WHEN the `shipping` field contains a `shop_pickup` object, THE `CartSerializer` SHALL serialize the `shop` field.
+
+---
+
+### Requirement 6: Discount Exemption for Delivery Fee
+
+**User Story:** As a platform operator, I want discount codes to never reduce the delivery fee, so that the €4 charge is always collected in full.
+
+#### Acceptance Criteria
+
+1. THE `Cart.get_cart_items_with_discounts` method SHALL return the `DeliveryFee` `CartItem` with `discount: None` unconditionally, regardless of any active `discount_code`.
+2. WHEN `Cart.discounts_by_value_desc` is called for the `DeliveryFee` item variant, THE `Cart` SHALL return an empty list.
+3. THE `Cart.amount` property SHALL compute the `DeliveryFee` at full price (400 cents) even when a discount code is active on the cart.

--- a/.kiro/specs/cart-delivery-shipping/tasks.md
+++ b/.kiro/specs/cart-delivery-shipping/tasks.md
@@ -1,0 +1,138 @@
+# Implementation Plan: Cart Delivery & Shipping
+
+## Overview
+
+Additive implementation that extends the existing cart with a `shipping` JSONField, a delivery-fee `ItemVariant` flag, a `DeliveryFeeService` helper, updated serializers, and extended cart state flags. No existing API contracts are broken.
+
+## Tasks
+
+- [x] 1. Add `is_delivery_fee` flag to `ItemVariant` and create migration
+  - Add `is_delivery_fee = models.BooleanField(default=False)` to `ItemVariant` in `api/models/item.py`
+  - Generate migration `api/migrations/0081_itemvariant_is_delivery_fee.py` via `makemigrations`
+  - _Requirements: 2.5, 6.2_
+
+- [x] 2. Add `shipping` JSONField to `Cart` and create migration
+  - Add `shipping = JSONField(blank=True, null=True)` to `Cart` in `api/models/cart.py`
+  - Generate migration `api/migrations/0082_cart_shipping.py` via `makemigrations`
+  - _Requirements: 1.1, 1.5_
+
+- [x] 3. Create data migration for the DeliveryFee Item and ItemVariant
+  - Write `api/migrations/0083_delivery_fee_item.py` as a data migration
+  - Create one `Item` (name="Delivery Fee", description="Home delivery surcharge") and one `ItemVariant` (price=4.00, stock=-1, `is_delivery_fee=True`)
+  - _Requirements: 2.1, 2.5_
+
+- [x] 4. Implement `DeliveryFeeService` helper
+  - [x] 4.1 Create `api/helpers/delivery_fee.py` with `ensure_delivery_fee(cart)` and `remove_delivery_fee(cart)`
+    - `ensure_delivery_fee`: look up `ItemVariant` where `is_delivery_fee=True`; add a `CartItems` row only if not already present
+    - `remove_delivery_fee`: delete any `CartItems` rows for that variant on the given cart
+    - _Requirements: 2.1, 2.2_
+
+  - [ ]* 4.2 Write unit tests for `DeliveryFeeService`
+    - Test `ensure_delivery_fee` is idempotent (calling twice adds only one row)
+    - Test `remove_delivery_fee` is a no-op when no fee row exists
+    - _Requirements: 2.1, 2.2_
+
+- [x] 5. Update discount logic in `Cart` to exempt the delivery fee
+  - [x] 5.1 Modify `Cart.get_cart_items_with_discounts` in `api/models/cart.py`
+    - When iterating, if `cart_item.item_variant.is_delivery_fee` is `True`, append `{..., 'discount': None}` and skip the discount lookup
+    - _Requirements: 2.4, 2.5, 6.1_
+
+  - [x] 5.2 Modify `Cart.discounts_by_value_desc` in `api/models/cart.py`
+    - Return `[]` immediately when `item_variant.is_delivery_fee` is `True`
+    - _Requirements: 6.2_
+
+  - [ ]* 5.3 Write property test for delivery fee discount exemption
+    - **Property 2: Delivery fee always excluded from discounts**
+    - **Validates: Requirements 2.4, 2.5, 6.1, 6.2**
+
+  - [ ]* 5.4 Write property test for cart amount with delivery fee
+    - **Property 3: Cart amount includes delivery fee at full price**
+    - **Validates: Requirements 2.3, 6.3**
+
+- [x] 6. Extend `Cart.state` with shipping selection flags
+  - In `Cart.state` property (`api/models/cart.py`), add:
+    - `needs_shipping_selection = self.shipping is None`
+    - `can_confirm_or_change_shipping = self.shipping is not None`
+  - _Requirements: 4.1, 4.2, 4.3_
+
+  - [ ]* 6.1 Write property test for cart state flags
+    - **Property 6: Cart state flags are consistent with shipping field**
+    - **Validates: Requirements 4.1, 4.2, 4.3**
+
+- [x] 7. Implement shipping serializers in `api/serializers/cart.py`
+  - [x] 7.1 Add `DeliverySerializer`, `ShopPickupSerializer`, and `ShippingSerializer`
+    - `DeliverySerializer`: fields `direccion`, `ciudad`, `telefono`, `dni` — all `CharField`, validate non-empty after strip
+    - `ShopPickupSerializer`: field `shop` — `CharField`, validate non-empty after strip
+    - `ShippingSerializer`: optional nested `delivery` and `shop_pickup`; `validate()` enforces exactly one non-null
+    - _Requirements: 1.2, 1.3, 1.4, 3.2, 3.3, 3.4_
+
+  - [ ]* 7.2 Write unit tests for `ShippingSerializer`
+    - Valid delivery payload accepted
+    - Valid shop_pickup payload accepted
+    - Both keys non-null → rejected (HTTP 400)
+    - Neither key present → rejected (HTTP 400)
+    - Empty `direccion` → rejected (HTTP 400)
+    - _Requirements: 3.2, 3.3, 3.4_
+
+  - [ ]* 7.3 Write property test for shipping serializer round-trip
+    - **Property 4: Shipping serializer round-trip**
+    - **Validates: Requirements 1.2, 1.3, 1.4, 5.4, 5.5**
+
+  - [ ]* 7.4 Write property test for invalid shipping rejection
+    - **Property 5: Invalid shipping payloads are rejected**
+    - **Validates: Requirements 3.2, 3.3, 3.4**
+
+- [x] 8. Checkpoint — Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 9. Update `CartSerializer` to handle the `shipping` field
+  - [x] 9.1 Add `shipping` as a writable field to `CartSerializer` in `api/serializers/cart.py`
+    - Use `ShippingSerializer(required=False, allow_null=True)` as the field
+    - Add `shipping` to `Meta.fields`; keep it writable (not in `read_only_fields`)
+    - _Requirements: 5.1, 5.2_
+
+  - [x] 9.2 Update `CartSerializer.update()` to persist shipping and manage the delivery fee
+    - If `shipping` is in `validated_data`, set `instance.shipping = validated_data['shipping']`
+    - If `delivery` key is non-null → call `ensure_delivery_fee(instance)`
+    - Otherwise → call `remove_delivery_fee(instance)`
+    - _Requirements: 3.1, 3.5, 3.6_
+
+  - [ ]* 9.3 Write unit tests for `CartSerializer` shipping field
+    - Serialized output includes `shipping: null` when unset
+    - PATCH with valid delivery payload updates `cart.shipping` and adds fee item
+    - PATCH with shop_pickup payload removes fee item
+    - _Requirements: 5.1, 5.2_
+
+  - [ ]* 9.4 Write property test for `CartSerializer` shipping field exposure
+    - **Property 7: CartSerializer exposes shipping field correctly**
+    - **Validates: Requirements 5.1, 5.3, 5.4, 5.5**
+
+- [x] 10. Update `CartCheckoutSerializer` to include the `shipping` field
+  - Add `shipping` to `CartCheckoutSerializer.Meta.fields`
+  - _Requirements: 5.3_
+
+  - [ ]* 10.1 Write unit test for `CartCheckoutSerializer` shipping field
+    - Serialized output includes `shipping` field
+    - _Requirements: 5.3_
+
+- [x] 11. Wire up and integration test the full PATCH flow
+  - [x] 11.1 Write integration tests in `api/tests/test_cart_shipping.py` extending `BaseTest`
+    - `PATCH /api/carts/{id}/` with delivery payload → 200, `shipping` set, fee item present
+    - `PATCH /api/carts/{id}/` switching to shop_pickup → fee item removed
+    - `PATCH /api/carts/{id}/` with malformed payload → 400
+    - Unauthenticated PATCH → 401
+    - _Requirements: 3.1, 3.4, 3.5, 3.6_
+
+  - [ ]* 11.2 Write property test for delivery fee presence iff delivery active
+    - **Property 1: Delivery fee present if and only if delivery is active**
+    - **Validates: Requirements 2.1, 2.2, 3.5, 3.6**
+
+- [x] 12. Final checkpoint — Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for a faster MVP
+- Property tests use [Hypothesis](https://hypothesis.readthedocs.io/) — add to dev dependencies if not present
+- Run tests with: `docker compose run --rm ameba-backend python manage.py test`
+- Migrations 0081–0083 must be applied before running the app: `docker compose run --rm ameba-backend python manage.py migrate`

--- a/.kiro/steering/product.md
+++ b/.kiro/steering/product.md
@@ -1,0 +1,14 @@
+# Product
+
+Ameba is a membership and cultural community platform for a music/arts collective (ameba.cat). The backend provides a REST API that powers:
+
+- Member registration, profiles, and membership management
+- Event listings and ticket management (with QR codes)
+- Artist and collaborator profiles
+- Editorial content (articles, interviews, covers)
+- E-commerce (cart, orders, items, discounts)
+- Subscriptions and payments via Stripe
+- Mailing list management via Mailgun
+- PDF generation for membership cards and tickets
+
+The platform supports multilingual content (Spanish, Catalan, English) and is used by both end-users and staff via a Django admin panel.

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -1,0 +1,48 @@
+# Project Structure
+
+```
+ameba-backend/
+├── config/               # Django project config (settings, root urls, wsgi/asgi)
+├── api/                  # Single Django app containing all business logic
+│   ├── models/           # One file per domain model (member, event, cart, etc.)
+│   ├── views/            # One file per resource; ViewSets + function-based views
+│   ├── serializers/      # One file per resource
+│   ├── admin/            # Django admin registrations, one file per model
+│   ├── docs/             # drf-yasg schema customizations and endpoint docs
+│   ├── tests/            # Test files mirror view/model names; BaseTest in _helpers.py
+│   ├── migrations/       # Django migrations (auto-generated)
+│   ├── serializers/      # DRF serializers
+│   ├── helpers/          # Utility modules (anonymization, signaling)
+│   ├── middleware/        # Custom middleware (language detection)
+│   ├── mocks/            # Test mocks (e.g. Stripe)
+│   ├── signals/          # Django signals
+│   ├── tasks/            # Background task definitions
+│   ├── locale/           # Translation files (es, ca, en)
+│   ├── management/commands/  # Custom manage.py commands
+│   ├── fixtures/         # Initial data fixtures
+│   ├── urls.py           # API URL routing (DRF router + manual paths)
+│   ├── authentication.py # Custom JWT authentication logic
+│   ├── permissions.py    # Custom DRF permission classes
+│   ├── cache_utils.py    # Redis cache decorators for views
+│   ├── email_factories.py# Email construction helpers
+│   ├── stripe.py         # Stripe webhook and payment logic
+│   ├── images.py         # Image processing utilities
+│   ├── qr_factories.py / qr_generator.py  # QR code generation
+│   └── responses.py      # Shared response helpers
+├── templates/            # Django HTML templates (admin overrides, emails)
+├── entrypoints/          # Docker entrypoint scripts (dev + prod)
+├── static/               # Collected static files
+├── media/                # User-uploaded media files
+└── manage.py
+```
+
+## Conventions
+
+- All API routes are prefixed with `/api/` and registered in `api/urls.py` using DRF's `DefaultRouter`.
+- ViewSets inherit from base classes in `api/views/base.py`: `BaseReadOnlyViewSet`, `BaseUserEditableViewSet`, or `BaseCrudViewSet`. These support separate `list_serializer` and `detail_serializer` per action.
+- Read-only public viewsets use `@cache_utils.cache_response` on `list` and `retrieve`.
+- Models use `@cache_utils.invalidate_models_cache` on `save()` to bust cache on writes.
+- Tests extend `BaseTest` (from `api/tests/_helpers.py`) which wraps `APITestCase` with helpers for authenticated requests (`_get`, `_create`, `_update`, `_partial_update`, `_list`, `_delete`).
+- i18n strings use `gettext_lazy` (`_()`) throughout models and serializers. Translatable model fields are registered in `api/translation.py`.
+- Custom `User` model is at `api/models/user.py`; always reference via `get_user_model()`.
+- Environment-specific config is read via the `env()` helper in `config/settings.py`, never hardcoded.

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -1,0 +1,61 @@
+# Tech Stack
+
+## Core
+- Python 3.10
+- Django 3.2
+- Django REST Framework 3.13
+- PostgreSQL 12 (via psycopg2)
+- Redis (django-redis, used for response caching)
+
+## Key Libraries
+- `djangorestframework-simplejwt` — JWT authentication (Bearer tokens)
+- `drf-yasg` — Swagger/OpenAPI docs at `/api/docs/` (DEBUG only)
+- `django-modeltranslation` — Model-level i18n (es/ca/en)
+- `django-anymail[mailgun]` — Transactional email via Mailgun
+- `stripe` — Payment processing and webhooks
+- `Pillow` — Image handling and resizing
+- `qrcode[pil]` — QR code generation for member cards and event tickets
+- `weasyprint` / `pdfkit` — PDF generation
+- `django-background-tasks` — Async background jobs
+- `Faker` — Test data generation
+- `gunicorn` — Production WSGI server
+
+## Infrastructure
+- Dockerized: all dev and prod workflows run via Docker Compose
+- Dev container support (VSCode devcontainer)
+- CI via Drone (`.drone.yml`)
+
+## Common Commands
+
+All commands run inside Docker:
+
+```bash
+# Start dev server
+docker compose up
+
+# Run tests
+docker compose run --rm ameba-backend python manage.py test
+
+# Apply migrations
+docker compose run --rm ameba-backend python manage.py migrate
+
+# Create new migrations
+docker compose run --rm ameba-backend python manage.py makemigrations
+
+# Compile i18n messages
+docker compose run --rm ameba-backend python manage.py compilemessages
+
+# Collect static files
+docker compose run --rm ameba-backend python manage.py collectstatic
+
+# Load local demo data
+docker compose run --rm ameba-backend python manage.py loadlocal
+
+# Create superuser
+docker compose run --rm ameba-backend python manage.py createsuperuser
+```
+
+## Environment
+Config is loaded from `.env` via the `envs` library. Key variables include `DJANGO_SECRET`, `POSTGRES_*`, `REDIS_LOC`, `STRIPE_*`, `MG_*` (Mailgun), and `EMAIL_*`.
+
+Settings module: `config.settings`

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "python.testing.cwd": "${workspaceFolder}",
     "python.testing.djangoEnabled": true,
-    "python.testing.djangoSettingsFile": "config/settings.py"
+    "python.testing.djangoSettingsFile": "config/settings.py",
+    "kiroAgent.configureMCP": "Disabled"
 }

--- a/api/helpers/delivery_fee.py
+++ b/api/helpers/delivery_fee.py
@@ -1,0 +1,15 @@
+from api.models import CartItems, ItemVariant
+
+DELIVERY_FEE_CENTS = 400
+
+
+def ensure_delivery_fee(cart) -> None:
+    """Add the DeliveryFee CartItem if not already present (idempotent)."""
+    variant = ItemVariant.objects.get(is_delivery_fee=True)
+    CartItems.objects.get_or_create(cart=cart, item_variant=variant)
+
+
+def remove_delivery_fee(cart) -> None:
+    """Remove the DeliveryFee CartItem if present (no-op if none exist)."""
+    variant = ItemVariant.objects.get(is_delivery_fee=True)
+    CartItems.objects.filter(cart=cart, item_variant=variant).delete()

--- a/api/migrations/0081_itemvariant_is_delivery_fee.py
+++ b/api/migrations/0081_itemvariant_is_delivery_fee.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0080_alter_member_number'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='itemvariant',
+            name='is_delivery_fee',
+            field=models.BooleanField(default=False, verbose_name='is delivery fee'),
+        ),
+    ]

--- a/api/migrations/0082_cart_shipping.py
+++ b/api/migrations/0082_cart_shipping.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0081_itemvariant_is_delivery_fee'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='cart',
+            name='shipping',
+            field=models.JSONField(blank=True, null=True, verbose_name='shipping'),
+        ),
+    ]

--- a/api/migrations/0083_delivery_fee_item.py
+++ b/api/migrations/0083_delivery_fee_item.py
@@ -1,0 +1,44 @@
+from django.db import migrations
+from django.utils import timezone
+
+# Use a high explicit ID to avoid collisions with test fixtures that use
+# small integer IDs (1–10). This value is well outside the range tests use.
+DELIVERY_FEE_ITEM_ID = 999998
+DELIVERY_FEE_VARIANT_ID = 999998
+
+
+def create_delivery_fee_item(apps, schema_editor):
+    Item = apps.get_model('api', 'Item')
+    ItemVariant = apps.get_model('api', 'ItemVariant')
+
+    item = Item.objects.create(
+        id=DELIVERY_FEE_ITEM_ID,
+        name='Delivery Fee',
+        description='Home delivery surcharge',
+        is_active=True,
+        order=timezone.now(),
+    )
+
+    ItemVariant.objects.create(
+        id=DELIVERY_FEE_VARIANT_ID,
+        item=item,
+        price=4.00,
+        stock=-1,
+        is_delivery_fee=True,
+    )
+
+
+def delete_delivery_fee_item(apps, schema_editor):
+    Item = apps.get_model('api', 'Item')
+    Item.objects.filter(id=DELIVERY_FEE_ITEM_ID).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0082_cart_shipping'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_delivery_fee_item, delete_delivery_fee_item),
+    ]

--- a/api/models/cart.py
+++ b/api/models/cart.py
@@ -56,6 +56,7 @@ class Cart(Model):
     checkout_hash = CharField(
         blank=True, max_length=128, verbose_name=_('checkout hash')
     )
+    shipping = JSONField(blank=True, null=True, verbose_name=_('shipping'))
 
     def delete(self, using=None, keep_parents=False):
         self.item_variants.clear()
@@ -97,6 +98,13 @@ class Cart(Model):
         discounts = []
         cart_items_by_price = self.cart_items_by_price_desc()
         for cart_item in cart_items_by_price:
+            if cart_item.item_variant.is_delivery_fee:
+                discounts.append({
+                    'item_variant': cart_item.item_variant,
+                    'discount': None,
+                    'cart_item': cart_item
+                })
+                continue
             discounts_by_value = self.discounts_by_value_desc(cart_item.item_variant)
             for discount in discounts_by_value:
                 if self.is_applicable(cart_discounts, discount):
@@ -120,6 +128,8 @@ class Cart(Model):
         return discount.remaining_usages(user) > cur_discounts.count(discount)
 
     def discounts_by_value_desc(self, item_variant):
+        if item_variant.is_delivery_fee:
+            return []
         if self.user:
             valid_dis = item_variant.item.get_valid_discounts(
                 self.user, self.discount_code
@@ -241,7 +251,9 @@ class Cart(Model):
             has_articles=len(self.articles),
             has_events=len(self.events),
             has_subscriptions=len(self.subscriptions),
-            needs_checkout=self.has_changed()
+            needs_checkout=self.has_changed(),
+            needs_shipping_selection=self.shipping is None,
+            can_confirm_or_change_shipping=self.shipping is not None,
         )
 
     def is_payment_succeeded(self):

--- a/api/models/item.py
+++ b/api/models/item.py
@@ -3,7 +3,7 @@ from django.utils import timezone
 from django.conf import settings
 from django.db.models import Sum
 from django.db import models
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 import api.cache_utils as cache_utils
 
 EXPIRE_HOURS_BEFORE_EVENT = 1
@@ -204,6 +204,7 @@ class ItemVariant(models.Model):
     )
     recurrence = models.CharField(max_length=10, choices=INTERVALS,
                                   blank=True, null=True, default=None)
+    is_delivery_fee = models.BooleanField(default=False, verbose_name=_('is delivery fee'))
 
     def get_valid_discounts(self, user, code=None):
         return self.item.get_valid_discounts(user, code)

--- a/api/serializers/cart.py
+++ b/api/serializers/cart.py
@@ -1,7 +1,68 @@
 import rest_framework.serializers as serializers
 import django.conf as conf
+from django.utils.translation import gettext_lazy as _
 
 import api.models as api_models
+from api.helpers.delivery_fee import ensure_delivery_fee, remove_delivery_fee
+
+
+class DeliverySerializer(serializers.Serializer):
+    direccion = serializers.CharField(label=_('address'))
+    ciudad = serializers.CharField(label=_('city'))
+    telefono = serializers.CharField(label=_('phone'))
+    dni = serializers.CharField(label=_('DNI'))
+
+    def validate_direccion(self, value):
+        value = value.strip()
+        if not value:
+            raise serializers.ValidationError(_('address cannot be empty'))
+        return value
+
+    def validate_ciudad(self, value):
+        value = value.strip()
+        if not value:
+            raise serializers.ValidationError(_('city cannot be empty'))
+        return value
+
+    def validate_telefono(self, value):
+        value = value.strip()
+        if not value:
+            raise serializers.ValidationError(_('phone cannot be empty'))
+        return value
+
+    def validate_dni(self, value):
+        value = value.strip()
+        if not value:
+            raise serializers.ValidationError(_('DNI cannot be empty'))
+        return value
+
+
+class ShopPickupSerializer(serializers.Serializer):
+    shop = serializers.CharField(label=_('shop'))
+
+    def validate_shop(self, value):
+        value = value.strip()
+        if not value:
+            raise serializers.ValidationError(_('shop cannot be empty'))
+        return value
+
+
+class ShippingSerializer(serializers.Serializer):
+    delivery = DeliverySerializer(required=False, allow_null=True)
+    shop_pickup = ShopPickupSerializer(required=False, allow_null=True)
+
+    def validate(self, data):
+        delivery = data.get('delivery')
+        shop_pickup = data.get('shop_pickup')
+        if delivery is not None and shop_pickup is not None:
+            raise serializers.ValidationError(
+                _('Only one of delivery or shop_pickup may be set at a time.')
+            )
+        if delivery is None and shop_pickup is None:
+            raise serializers.ValidationError(
+                _('At least one of delivery or shop_pickup must be provided.')
+            )
+        return data
 
 
 class CartItemSerializer(serializers.Serializer):
@@ -86,12 +147,13 @@ class CartSerializer(serializers.ModelSerializer):
         many=True, queryset=api_models.ItemVariant.objects.all(),
         slug_field='id', required=False, source='item_variants'
     )
+    shipping = ShippingSerializer(required=False, allow_null=True)
 
     class Meta:
         model = api_models.Cart
         fields = (
             'id', 'user', 'total', 'count', 'item_variant_ids', 'item_variants',
-            'discount_code', 'state'
+            'discount_code', 'state', 'shipping'
         )
         read_only_fields = (
             'user', 'id', 'total', 'count', 'item_variants', 'state'
@@ -117,6 +179,12 @@ class CartSerializer(serializers.ModelSerializer):
             self._add_cart_items(instance, validated_data['item_variants'])
         if 'discount_code' in validated_data:
             instance.discount_code = validated_data.get('discount_code')
+        if 'shipping' in validated_data:
+            instance.shipping = validated_data['shipping']
+            if validated_data['shipping'] is not None and validated_data['shipping'].get('delivery') is not None:
+                ensure_delivery_fee(instance)
+            else:
+                remove_delivery_fee(instance)
         instance.save()
         return instance
 
@@ -160,7 +228,7 @@ class CartCheckoutSerializer(CartSerializer):
     class Meta:
         model = api_models.Cart
         fields = ('user', 'email', 'total', 'amount', 'item_variants',
-                  'checkout')
+                  'checkout', 'shipping')
 
     @property
     def username(self):

--- a/api/tests/cart.py
+++ b/api/tests/cart.py
@@ -123,17 +123,20 @@ class TestGetCart(BaseCartTest):
             "user": None,
             "total": "0.00 €",
             "count": 0,
-            "item_variants": [],
             "item_variant_ids": [],
+            "item_variants": [],
             "discount_code": None,
+            "shipping": None,
             "state": {
                 "has_user": False,
                 "has_member_profile": False,
                 "has_memberships": False,
-                "has_articles": False,
-                "has_events": False,
-                "has_subscriptions": False,
-                "needs_checkout": True
+                "has_articles": 0,
+                "has_events": 0,
+                "has_subscriptions": 0,
+                "needs_checkout": True,
+                "needs_shipping_selection": True,
+                "can_confirm_or_change_shipping": False,
             }
         }
 
@@ -683,6 +686,28 @@ class TestCartStateFlow(BaseCartTest):
         self.assertFalse(cart_state['has_events'])
         self.assertFalse(cart_state['has_subscriptions'])
         self.assertTrue(cart_state['needs_checkout'])
+
+    def test_cart_state_without_shipping_needs_shipping_selection(self):
+        user = self.get_user(1)
+        token = self.get_token(user).access_token
+        cart = self.get_cart(user=user, item_variants=[1, 2])
+        cart.shipping = None
+        cart.save()
+        response = self._get(pk=cart.id, token=token)
+        cart_state = response.data.get('state')
+        self.assertTrue(cart_state['needs_shipping_selection'])
+        self.assertFalse(cart_state['can_confirm_or_change_shipping'])
+
+    def test_cart_state_with_shipping_set_can_confirm_or_change(self):
+        user = self.get_user(1)
+        token = self.get_token(user).access_token
+        cart = self.get_cart(user=user, item_variants=[1, 2])
+        cart.shipping = {'shop_pickup': {'shop': 'Main Store'}}
+        cart.save()
+        response = self._get(pk=cart.id, token=token)
+        cart_state = response.data.get('state')
+        self.assertFalse(cart_state['needs_shipping_selection'])
+        self.assertTrue(cart_state['can_confirm_or_change_shipping'])
 
 
 class TestRegisterWithCart(BaseCartTest):

--- a/api/tests/test_cart_shipping.py
+++ b/api/tests/test_cart_shipping.py
@@ -1,0 +1,125 @@
+from rest_framework import status
+
+from api.models import ItemVariant
+from api.models.cart import CartItems
+from api.tests.cart import BaseCartTest
+
+
+class TestCartShipping(BaseCartTest):
+
+    def test_patch_with_delivery_payload_sets_shipping_and_adds_fee_item(self):
+        """Requirements: 3.1, 3.6, 2.1"""
+        user = self.get_user()
+        token = self.get_token(user).access_token
+        cart = self.get_cart(user=user)
+
+        body = {
+            'shipping': {
+                'delivery': {
+                    'direccion': 'Calle Mayor 1',
+                    'ciudad': 'Barcelona',
+                    'telefono': '612345678',
+                    'dni': '12345678A',
+                }
+            }
+        }
+
+        response = self._partial_update(pk=cart.id, token=token, props=body)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.data['shipping']['delivery']['direccion'], 'Calle Mayor 1'
+        )
+
+        delivery_fee_variant = ItemVariant.objects.filter(is_delivery_fee=True).first()
+        self.assertIsNotNone(delivery_fee_variant)
+
+        cart.refresh_from_db()
+        self.assertTrue(cart.item_variants.filter(is_delivery_fee=True).exists())
+
+    def test_patch_switching_to_shop_pickup_removes_fee_item(self):
+        """Requirements: 3.5, 2.2"""
+        user = self.get_user()
+        token = self.get_token(user).access_token
+        cart = self.get_cart(user=user)
+
+        # Set delivery shipping and add the fee item manually
+        cart.shipping = {
+            'delivery': {
+                'direccion': 'Calle Mayor 1',
+                'ciudad': 'Barcelona',
+                'telefono': '612345678',
+                'dni': '12345678A',
+            }
+        }
+        cart.save()
+
+        delivery_fee_variant = ItemVariant.objects.get(is_delivery_fee=True)
+        CartItems.objects.get_or_create(cart=cart, item_variant=delivery_fee_variant)
+
+        # Confirm fee is present before switching
+        self.assertTrue(cart.item_variants.filter(is_delivery_fee=True).exists())
+
+        body = {'shipping': {'shop_pickup': {'shop': 'Main Store'}}}
+        response = self._partial_update(pk=cart.id, token=token, props=body)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['shipping']['shop_pickup']['shop'], 'Main Store')
+
+        cart.refresh_from_db()
+        self.assertFalse(cart.item_variants.filter(is_delivery_fee=True).exists())
+
+    def test_patch_with_malformed_shipping_payload_returns_400(self):
+        """Requirements: 3.4 — empty direccion should be rejected"""
+        user = self.get_user()
+        token = self.get_token(user).access_token
+        cart = self.get_cart(user=user)
+
+        body = {
+            'shipping': {
+                'delivery': {
+                    'direccion': '',
+                    'ciudad': 'Barcelona',
+                    'telefono': '612345678',
+                    'dni': '12345678A',
+                }
+            }
+        }
+
+        response = self._partial_update(pk=cart.id, token=token, props=body)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_patch_with_both_delivery_and_pickup_returns_400(self):
+        """Requirements: 3.4 — both delivery and shop_pickup non-null is invalid"""
+        user = self.get_user()
+        token = self.get_token(user).access_token
+        cart = self.get_cart(user=user)
+
+        body = {
+            'shipping': {
+                'delivery': {
+                    'direccion': 'Calle Mayor 1',
+                    'ciudad': 'Barcelona',
+                    'telefono': '612345678',
+                    'dni': '12345678A',
+                },
+                'shop_pickup': {'shop': 'Main Store'},
+            }
+        }
+
+        response = self._partial_update(pk=cart.id, token=token, props=body)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_patch_unauthenticated_returns_401(self):
+        """Security: unauthenticated PATCH on a user-owned cart must be rejected"""
+        user = self.get_user()
+        cart = self.get_cart(user=user)
+
+        body = {'shipping': {'shop_pickup': {'shop': 'Main Store'}}}
+
+        # No token passed → unauthenticated request
+        response = self._partial_update(pk=cart.id, token=None, props=body)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)


### PR DESCRIPTION
**done with Kiro**

This feature adds shipping/delivery support to the Ameba cart. Users choose between home delivery or shop pickup at checkout. The choice is persisted as a `shipping` JSONField on the `Cart` model. Selecting home delivery automatically adds a fixed €4 `DeliveryFee` `CartItem` that is always excluded from discount calculations. The cart's `state` property is extended with two flags that drive the frontend checkout routing.

The implementation is additive: no existing model fields are removed, no existing API contracts are broken. The `CartViewSet` already supports `PATCH /api/carts/{id}/` via `partial_update`; we extend the `CartSerializer` to accept and validate the new `shipping` field through that same endpoint.